### PR TITLE
fix(eslint_hook): rename .eslintrc to .eslintrc.json

### DIFF
--- a/hooks/eslint/index.js
+++ b/hooks/eslint/index.js
@@ -19,8 +19,8 @@ const func = (cwd, folderName) => {
   console.log(`${emoji.get('fire')}  ${chalk.cyan('Installing eslint')} ${emoji.get('fire')}`)
   console.log('\n\n')
 
-  return fs.copy(`${__dirname}/.eslintrc.json`, `${cwd}/${folderName}/.eslintrc`)
-      .then(() => addEslintFileSuccess(cwd, folderName))
+  return fs.copy(`${__dirname}/.eslintrc.json`, `${cwd}/${folderName}/.eslintrc.json`)
+    .then(() => addEslintFileSuccess(cwd, folderName))
 }
 
 const addEslintFileSuccess = (cwd, folderName) => {


### PR DESCRIPTION
this 3cb1ae71eac208724bf767ca5504c6b993d9385f renamed only the source name, but forgot to rename the destination file